### PR TITLE
Fix σ1 rotation and shift values

### DIFF
--- a/src/components/Explainer.js
+++ b/src/components/Explainer.js
@@ -130,7 +130,7 @@ function Explainer({ clock, input, inputBase, chunksCount, lastClock, masterCloc
         <div className="pb-2">
           <div className="flex">
             <div className="mr-2">σ1 =</div>
-            <div>(<b className="text-green-500">w{ clock + 12 }</b> rightrotate  7) xor <br/>(<b className="text-green-500">w{ clock + 12 }</b> rightrotate 18) xor <br/>(<b className="text-green-500">w{ clock + 12 }</b> rightshift  3)</div>
+            <div>(<b className="text-green-500">w{ clock + 12 }</b> rightrotate  17) xor <br/>(<b className="text-green-500">w{ clock + 12 }</b> rightrotate 19) xor <br/>(<b className="text-green-500">w{ clock + 12 }</b> rightshift 10)</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The two rotations and shift for σ1 should be 17, 19 and 10 respectively. Instead, the explainer uses the same values as σ0. Likely a copy-paste bug. :)