### PR TITLE
Fix incorrect initial hash values on second and later chunks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -279,7 +279,8 @@ function App() {
         w[i] = parseInt(messageWord, 2)
       });
 
-      for(let i = 16; i <= firstLoop; i++) { //63
+      let firstLoopForCurrentChunk = n < chunksLoop - 1 ? 63 : firstLoop;
+      for(let i = 16; i <= firstLoopForCurrentChunk; i++) { //63
         s0 = (rotateRight(w[i-15], 7) ^ rotateRight(w[i-15], 18) ^ (w[i-15] >>> 3)) >>> 0;
         s1 = (rotateRight(w[i-2], 17) ^ rotateRight(w[i-2], 19) ^ (w[i-2] >>> 10)) >>> 0;
         w[i] = (w[i-16] + s0 + w[i-7] + s1)%(2**32)
@@ -287,7 +288,8 @@ function App() {
 
       a = h0; b = h1; c = h2; d = h3; e = h4; f = h5; g = h6; h = h7;
 
-      for(let i = 0; i <= secondLoop; i++) { // 63
+      let secondLoopForCurrentChunk = n < chunksLoop - 1 ? 63 : secondLoop;
+      for(let i = 0; i <= secondLoopForCurrentChunk; i++) { // 63
         S1 = (rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)) >>> 0;
         ch = (e & f) ^ ((~e) & g) >>> 0;
         temp1 = (h + S1 + ch + k[i] + w[i])%(2**32) >>> 0;


### PR DESCRIPTION
### Summary

This PR will fix an issue that initial hash value on the second chunk isn't same as the updated hash value on the first chunk. 

*Issue screenshot 1: updated `h0` on the first chunk is `10101110101011001101110101110000`.*
![Issue screenshot 1](https://user-images.githubusercontent.com/29354589/153089131-a8048f0a-49eb-44d3-b565-1001ea72e1bd.png)

*Issue screenshot 2: initial `h0` on the second chunk is `11000111011101001101001000011000`.*
![Issue screenshot 2](https://user-images.githubusercontent.com/29354589/153089477-bfbc9124-a843-49fb-903b-afec80674283.png)

The issue is caused because the `for` loop iterating `secondLoop` times in `shaStepped()` doesn't iterate maximum `secondLoop` times, i.e. 63 times, on the first chunk before entering into the second chunk and iterating `secondLoop` times on the second chunk. For example if `secondLoop` is `5`, the `for` loop will iterate 5 times on the first chunk and 5 times on the second chunk. Instead it should iterate 63 times on the first chunk and 5 times on the second chunk.

https://github.com/dmarman/sha256algorithm/blob/43f698c8f04a9bd8a0720b96c3fd99e1bd480fb8/src/App.js#L285-L347

### Test plan

1. Paste "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" into input field.
2. Advance to step 113 and check if updated value of `h0` is `10101110101011001101110101110000`.
3. Advance to step 164 and check if initial value of `h0` is `10101110101011001101110101110000`.